### PR TITLE
Add clap hello world

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {}
+
 fn main() {
-    println!("Hello, world!");
+    let _args = Args::parse();
+    println!("hello world");
 }


### PR DESCRIPTION
## Summary
- wire up clap via `clap` crate
- print `hello world` after parsing args

## Testing
- `cargo build` *(fails: failed to download from `https://index.crates.io/...`)*

------
https://chatgpt.com/codex/tasks/task_e_6863b68618cc832ab5c07da0f85bf10b