### PR TITLE
Implement basic trash functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+trash = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,18 @@
 use clap::Parser;
+use std::path::PathBuf;
 
+/// Move the specified file to the system trash.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-struct Args {}
+struct Args {
+    /// Path to the file or directory to trash
+    path: PathBuf,
+}
 
 fn main() {
-    let _args = Args::parse();
-    println!("hello world");
+    let args = Args::parse();
+
+    if let Err(e) = trash::delete(&args.path) {
+        eprintln!("failed to trash {}: {}", args.path.display(), e);
+    }
 }


### PR DESCRIPTION
## Summary
- parse a path argument
- move the provided file to the OS trash using the `trash` crate
- add `trash` dependency

## Testing
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6863b7ff93f8832ab9a39937c0e8caa1