### PR TITLE
Add separate rm and cp binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,14 @@ name = "safecmd"
 version = "0.1.0"
 edition = "2024"
 
+[[bin]]
+name = "rm"
+path = "src/bin/rm.rs"
+
+[[bin]]
+name = "cp"
+path = "src/bin/cp.rs"
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 dirs = "5"

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -104,6 +104,12 @@ impl AllowlistChecker {
     }
 }
 
+impl Default for AllowlistChecker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,19 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Move the specified file to the system trash.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    /// Allow removing empty directories
+    #[arg(short = 'd')]
+    pub allow_dir: bool,
+    /// Force removal without prompting, ignore non-existent files
+    #[arg(short = 'f')]
+    pub force: bool,
+    /// Recursively remove directories
+    #[arg(short = 'r')]
+    pub recursive: bool,
+    /// Paths to files or directories to trash
+    pub path: Vec<PathBuf>,
+}

--- a/src/bin/cp.rs
+++ b/src/bin/cp.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("hello world");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,10 +50,10 @@ impl Config {
         }
 
         let content = fs::read_to_string(&config_path)
-            .map_err(|e| format!("Failed to read config file: {}", e))?;
+            .map_err(|e| format!("Failed to read config file: {e}"))?;
 
         let config: Config =
-            toml::from_str(&content).map_err(|e| format!("Failed to parse config file: {}", e))?;
+            toml::from_str(&content).map_err(|e| format!("Failed to parse config file: {e}"))?;
 
         Ok(config)
     }
@@ -202,7 +202,7 @@ impl Config {
     fn create_default_config(config_path: &Path) -> Result<(), String> {
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create config directory: {}", e))?;
+                .map_err(|e| format!("Failed to create config directory: {e}"))?;
         }
 
         let default_content = r#"# SafeCmd configuration file
@@ -217,10 +217,10 @@ paths = [
 "#;
 
         let mut file = fs::File::create(config_path)
-            .map_err(|e| format!("Failed to create config file: {}", e))?;
+            .map_err(|e| format!("Failed to create config file: {e}"))?;
 
         file.write_all(default_content.as_bytes())
-            .map_err(|e| format!("Failed to write default config: {}", e))?;
+            .map_err(|e| format!("Failed to write default config: {e}"))?;
 
         Err(format!(
             "Created default configuration file at: {}\nPlease add allowed directories to the config file and try again.",

--- a/src/gitignore.rs
+++ b/src/gitignore.rs
@@ -104,6 +104,12 @@ impl GitignoreChecker {
     }
 }
 
+impl Default for GitignoreChecker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod allowlist;
+pub mod config;
+pub mod gitignore;
+pub mod strategy;
+pub mod args;

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,4 +1,4 @@
-use crate::{Args, allowlist::AllowlistChecker, config::Config, gitignore::GitignoreChecker};
+use crate::{args::Args, allowlist::AllowlistChecker, config::Config, gitignore::GitignoreChecker};
 use std::path::Path;
 
 pub trait RemovalStrategy {

--- a/tests/allowlist_integration.rs
+++ b/tests/allowlist_integration.rs
@@ -18,7 +18,7 @@ fn test_allowlist_overrides_gitignore() {
     fs::write(temp_path.join("debug.log"), "debug content").unwrap();
     fs::write(temp_path.join("error.log"), "error content").unwrap();
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // debug.log should be removable (allowed by .allowsafecmd)
     cmd.arg(temp_path.join("debug.log")).assert().success();
@@ -26,7 +26,7 @@ fn test_allowlist_overrides_gitignore() {
     // Verify file was removed
     assert!(!temp_path.join("debug.log").exists());
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // error.log should still be protected (not in .allowsafecmd)
     cmd.arg(temp_path.join("error.log"))
@@ -53,7 +53,7 @@ fn test_allowlist_directory_pattern() {
     fs::create_dir(temp_path.join("build")).unwrap();
     fs::write(temp_path.join("build/output.bin"), "binary").unwrap();
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // build directory should be removable with -r flag
     cmd.arg("-r")
@@ -81,14 +81,14 @@ fn test_allowlist_wildcard_patterns() {
     fs::write(temp_path.join("data.tmp"), "data").unwrap();
     fs::write(temp_path.join("index.cache"), "index").unwrap();
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // cache.tmp should be removable (explicitly allowed)
     cmd.arg(temp_path.join("cache.tmp")).assert().success();
 
     assert!(!temp_path.join("cache.tmp").exists());
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // data.tmp should be protected (not in allowlist)
     cmd.arg(temp_path.join("data.tmp"))
@@ -98,7 +98,7 @@ fn test_allowlist_wildcard_patterns() {
 
     assert!(temp_path.join("data.tmp").exists());
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // index.cache should be removable (matches *.cache pattern)
     cmd.arg(temp_path.join("index.cache")).assert().success();
@@ -129,20 +129,20 @@ fn test_nested_allowlist_files() {
     fs::write(sub_dir.join("data.secret"), "data").unwrap();
     fs::write(sub_dir.join("key.secret"), "key").unwrap();
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // Both test.secret and data.secret should be removable
     cmd.arg(sub_dir.join("test.secret")).assert().success();
 
     assert!(!sub_dir.join("test.secret").exists());
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     cmd.arg(sub_dir.join("data.secret")).assert().success();
 
     assert!(!sub_dir.join("data.secret").exists());
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // key.secret should still be protected
     cmd.arg(sub_dir.join("key.secret"))
@@ -164,7 +164,7 @@ fn test_allowlist_without_gitignore() {
     // Create test file
     fs::write(temp_path.join("app.log"), "log").unwrap();
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // File should be removable (no gitignore protection)
     cmd.arg(temp_path.join("app.log")).assert().success();
@@ -192,7 +192,7 @@ fn test_allowlist_files_in_gitignored_directory() {
     fs::create_dir(&node_modules).unwrap();
     fs::write(node_modules.join("package.json"), "{}").unwrap();
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     // Files in allowed directory should be removable
     cmd.arg(node_modules.join("package.json"))
@@ -202,7 +202,7 @@ fn test_allowlist_files_in_gitignored_directory() {
     assert!(!node_modules.join("package.json").exists());
 
     // Directory itself should also be removable with -r
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
 
     cmd.arg("-r").arg(&node_modules).assert().success();
 

--- a/tests/config_allowed_directories_integration.rs
+++ b/tests/config_allowed_directories_integration.rs
@@ -29,7 +29,7 @@ paths = ["{}"]
     fs::write(temp_path.join("disallowed.txt"), "disallowed").unwrap();
 
     // Test: allowed directory - should succeed
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&allowed_dir)
@@ -40,7 +40,7 @@ paths = ["{}"]
     assert!(!allowed_dir.join("test.txt").exists());
 
     // Test: disallowed directory - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(temp_path)
@@ -80,7 +80,7 @@ paths = ["{}"]
     fs::write(subproject_dir.join("file.txt"), "content").unwrap();
 
     // Test: subdirectory of allowed directory - should succeed
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&subproject_dir)
@@ -120,7 +120,7 @@ paths = ["{}", "{}"]
     fs::write(dir2.join("file2.txt"), "content2").unwrap();
 
     // Test both directories
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&dir1)
@@ -130,7 +130,7 @@ paths = ["{}", "{}"]
 
     assert!(!dir1.join("file1.txt").exists());
 
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&dir2)
@@ -169,7 +169,7 @@ paths = ["{}"]
     fs::write(&disallowed_file, "secret").unwrap();
 
     // Test: try to delete file outside allowed directory using absolute path
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&allowed_dir)
@@ -201,7 +201,7 @@ paths = []
     fs::write(temp_path.join("file.txt"), "content").unwrap();
 
     // Test: empty allowed directories - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(temp_path)
@@ -223,7 +223,7 @@ fn test_config_creation_error_message() {
     let config_path = temp_path.join("nonexistent").join("config.toml");
 
     // Test: config file doesn't exist and can't be created - should show error
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(temp_path)
@@ -273,7 +273,7 @@ paths = ["{}"]
     fs::write(symlink_dir.join("file.txt"), "content").unwrap();
 
     // Test: accessing through symlink when real path is allowed - should succeed
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&symlink_dir)
@@ -310,7 +310,7 @@ paths = ["{}"]
     fs::write(subdir.join("file2.txt"), "content2").unwrap();
 
     // Test: simple relative path
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&allowed_dir)
@@ -322,7 +322,7 @@ paths = ["{}"]
 
     // Test: relative path with ./
     fs::write(allowed_dir.join("file3.txt"), "content3").unwrap();
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&allowed_dir)
@@ -333,7 +333,7 @@ paths = ["{}"]
     assert!(!allowed_dir.join("file3.txt").exists());
 
     // Test: relative path to subdirectory
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&allowed_dir)
@@ -370,7 +370,7 @@ paths = ["{}"]
     fs::write(&config_path, config_content).unwrap();
 
     // Test: try to access parent directory file with ../
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&subdir)
@@ -385,7 +385,7 @@ paths = ["{}"]
 
     // But accessing files within allowed directory via .. should work
     fs::write(allowed_dir.join("allowed_file.txt"), "content").unwrap();
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&subdir)
@@ -424,7 +424,7 @@ paths = ["{}"]
     fs::write(subdir2.join("target.txt"), "target").unwrap();
 
     // Test: complex path like ./subdir1/../root_file.txt
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&allowed_dir)
@@ -435,7 +435,7 @@ paths = ["{}"]
     assert!(!allowed_dir.join("root_file.txt").exists());
 
     // Test: accessing sibling directory from subdirectory
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&subdir1)
@@ -471,7 +471,7 @@ paths = ["{}"]
     fs::write(deep_subdir.join("deep_file.txt"), "deep").unwrap();
 
     // Test: relative path from deep subdirectory
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&deep_subdir)
@@ -509,7 +509,7 @@ paths = ["{}"]
     fs::write(&allowed_file, "allowed").unwrap();
 
     // Test: try to delete allowed file from disallowed directory
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.env("SAFECMD_CONFIG_PATH", &config_path)
         .env("SAFECMD_DISABLE_TEST_MODE", "1")
         .current_dir(&disallowed_dir)

--- a/tests/gitignore_integration.rs
+++ b/tests/gitignore_integration.rs
@@ -22,7 +22,7 @@ fn test_gitignore_prevents_deletion() {
     fs::write(temp_path.join("regular.txt"), "regular data").unwrap();
 
     // Test: Try to delete a gitignored file - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("important.txt")
         .assert()
@@ -30,7 +30,7 @@ fn test_gitignore_prevents_deletion() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: Try to delete a gitignored pattern - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("app.log")
         .assert()
@@ -38,7 +38,7 @@ fn test_gitignore_prevents_deletion() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: Try to delete a gitignored directory - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("-r")
         .arg("build")
@@ -47,7 +47,7 @@ fn test_gitignore_prevents_deletion() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: Even with -f flag, gitignored files should not be deleted
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("-f")
         .arg("important.txt")
@@ -56,7 +56,7 @@ fn test_gitignore_prevents_deletion() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: Regular file can be deleted
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("regular.txt")
         .assert()
@@ -93,7 +93,7 @@ fn test_gitignore_prevents_deletion_of_files_in_ignored_directory() {
     fs::write(temp_path.join("src/main.rs"), "source code").unwrap();
 
     // Test: Try to delete a file inside gitignored directory - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("build/output.bin")
         .assert()
@@ -101,7 +101,7 @@ fn test_gitignore_prevents_deletion_of_files_in_ignored_directory() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: Try to delete another file in gitignored directory - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("build/debug.log")
         .assert()
@@ -109,7 +109,7 @@ fn test_gitignore_prevents_deletion_of_files_in_ignored_directory() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: Try to delete file in different gitignored directory - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("cache/temp.dat")
         .assert()
@@ -117,7 +117,7 @@ fn test_gitignore_prevents_deletion_of_files_in_ignored_directory() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: Even with -f flag, files in gitignored directories should not be deleted
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("-f")
         .arg("build/output.bin")
@@ -126,7 +126,7 @@ fn test_gitignore_prevents_deletion_of_files_in_ignored_directory() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: File in non-ignored directory can be deleted
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("src/main.rs")
         .assert()
@@ -154,7 +154,7 @@ fn test_gitignore_with_nested_directories() {
     fs::write(temp_path.join("secrets/deep/key.pem"), "key").unwrap();
 
     // Test: Try to delete gitignored nested directory
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("-r")
         .arg("secrets")
@@ -185,7 +185,7 @@ fn test_gitignore_respects_parent_directory() {
     fs::write(subdir.join("data.txt"), "normal data").unwrap();
 
     // Test: Parent .gitignore should be respected
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&subdir)
         .arg("data.secret")
         .assert()
@@ -193,7 +193,7 @@ fn test_gitignore_respects_parent_directory() {
         .stderr(predicate::str::contains("protected by .gitignore"));
 
     // Test: Non-gitignored file can be deleted
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&subdir).arg("data.txt").assert().success();
 
     // Verify results

--- a/tests/nested_gitignore_recursive.rs
+++ b/tests/nested_gitignore_recursive.rs
@@ -22,7 +22,7 @@ fn test_recursive_deletion_respects_nested_gitignore() {
     fs::write(temp_path.join("allowed/some_dir/file1.txt"), "content1").unwrap();
 
     // Test: Try to recursively delete a subdirectory of gitignored directory - should fail
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("-r")
         .arg("dist/some_dir")
@@ -36,7 +36,7 @@ fn test_recursive_deletion_respects_nested_gitignore() {
     assert!(temp_path.join("dist/some_dir/file2.txt").exists());
 
     // Test: Non-ignored directory can be deleted
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("-r")
         .arg("allowed/some_dir")
@@ -63,7 +63,7 @@ fn test_recursive_deletion_checks_all_contents() {
 
     // Test: Try to recursively delete the project directory - should fail
     // because it contains gitignored content
-    let mut cmd = Command::cargo_bin("safecmd").unwrap();
+    let mut cmd = Command::cargo_bin("rm").unwrap();
     cmd.current_dir(&temp_path)
         .arg("-r")
         .arg("project")

--- a/tests/trash_integration.rs
+++ b/tests/trash_integration.rs
@@ -12,7 +12,7 @@ fn file_is_trashed() {
     File::create(&file_path).expect("create file");
 
     // run the binary
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg(&file_path)
         .assert()
@@ -30,7 +30,7 @@ fn directory_without_flags_fails() {
     fs::create_dir(&dir_path).expect("create directory");
 
     // run the binary without flags (should fail)
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg(&dir_path)
         .assert()
@@ -49,7 +49,7 @@ fn empty_directory_with_d_flag() {
     fs::create_dir(&dir_path).expect("create directory");
 
     // run the binary with -d flag
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-d")
         .arg(&dir_path)
@@ -72,7 +72,7 @@ fn non_empty_directory_with_d_flag_fails() {
     File::create(dir_path.join("file.txt")).expect("create file");
 
     // run the binary with -d flag (should fail)
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-d")
         .arg(&dir_path)
@@ -104,7 +104,7 @@ fn directory_with_r_flag() {
     File::create(sub_dir.join("file3.txt")).expect("create file3");
 
     // run the binary with -r flag
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-r")
         .arg(&dir_path)
@@ -121,7 +121,7 @@ fn directory_with_r_flag() {
 #[test]
 fn non_existent_file_without_f_flag_fails() {
     // run the binary on a non-existent file without -f
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("non_existent_file.txt")
         .assert()
@@ -132,7 +132,7 @@ fn non_existent_file_without_f_flag_fails() {
 #[test]
 fn non_existent_file_with_f_flag_succeeds() {
     // run the binary on a non-existent file with -f
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-f")
         .arg("non_existent_file.txt")
@@ -148,7 +148,7 @@ fn mixed_files_with_f_flag() {
     File::create(&existing_file).expect("create file");
 
     // run the binary with -f on both existing and non-existent files
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-f")
         .arg(&existing_file)
@@ -169,7 +169,7 @@ fn combined_flags_rf() {
     fs::create_dir(&dir_path).expect("create directory");
     File::create(dir_path.join("file.txt")).expect("create file");
 
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-rf")
         .arg(&dir_path)
@@ -187,7 +187,7 @@ fn combined_flags_fr() {
     fs::create_dir(&dir_path).expect("create directory");
     File::create(dir_path.join("file.txt")).expect("create file");
 
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-fr")
         .arg(&dir_path)
@@ -204,7 +204,7 @@ fn combined_flags_df() {
     let empty_dir = temp_dir.path().join("empty_dir");
     fs::create_dir(&empty_dir).expect("create directory");
 
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-df")
         .arg(&empty_dir)
@@ -225,7 +225,7 @@ fn combined_flags_drf() {
     fs::create_dir(&dir_path).expect("create directory");
     File::create(dir_path.join("file.txt")).expect("create file");
 
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-drf")
         .arg(&dir_path)
@@ -242,7 +242,7 @@ fn combined_flags_frd() {
     let existing_dir = temp_dir.path().join("existing");
     fs::create_dir(&existing_dir).expect("create directory");
 
-    Command::cargo_bin("safecmd")
+    Command::cargo_bin("rm")
         .expect("binary exists")
         .arg("-frd")
         .arg(&existing_dir)


### PR DESCRIPTION
## Summary
- add `rm` and `cp` binary targets
- move existing safe rm implementation to `src/bin/rm.rs`
- create minimal `cp` binary printing `hello world`
- expose internal modules via a library crate
- update integration tests to invoke the `rm` binary

## Testing
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686653dfe0c8832aacccf8903b7978c8